### PR TITLE
fix: updating build command script for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "",
   "license": "MIT",
   "scripts": {
-    "build": "webpack --config webpack.config.js",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider webpack --config webpack.config.js",
     "watch": "webpack --config webpack.config.js --watch --progress",
     "lint": "tslint --project tsconfig.json --format stylish 'src/**/*.ts'",
     "lint-fix": "tslint --fix --project tsconfig.json  --format stylish 'src/**/*.ts'",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "license": "MIT",
   "scripts": {
-    "build": "NODE_OPTIONS=--openssl-legacy-provider webpack --config webpack.config.js",
+    "build": "webpack --config webpack.config.js",
+    "build:legacy": "env NODE_OPTIONS='--openssl-legacy-provider' webpack --config webpack.config.js",
     "watch": "webpack --config webpack.config.js --watch --progress",
     "lint": "tslint --project tsconfig.json --format stylish 'src/**/*.ts'",
     "lint-fix": "tslint --fix --project tsconfig.json  --format stylish 'src/**/*.ts'",


### PR DESCRIPTION
Script fix to avoid ```Error: error:0308010C:digital envelope routines::unsupported``` while running build.